### PR TITLE
Expose issue timestamps

### DIFF
--- a/lib/github.atd
+++ b/lib/github.atd
@@ -165,6 +165,9 @@ type issue = {
   user: user;
   labels: label list;
   ~comments: int;
+  ~created_at: string;
+  ~updated_at: string;
+  ~closed_at: string option;
   ?milestone: milestone option;
   ~sort <ocaml default="`Created">: issue_sort;
   ~direction <ocaml default="`Desc">: direction;


### PR DESCRIPTION
This is for https://github.com/avsm/ocaml-github/issues/50. It seems to work, if you fell there is something to change, just let me know.

Reviewing the JSON response of Github demonstrates that the `updated_at` field is always there, it might be equal to the `created_at` filed if there is no modification after creation.