### PR TITLE
Import opam file from the opam repository

### DIFF
--- a/opam
+++ b/opam
@@ -1,4 +1,4 @@
-opam-version: "1"
+opam-version: "1.2"
 maintainer: "anil@recoil.org"
 homepage: "https://github.com/avsm/ocaml-github"
 dev-repo: "https://github.com/avsm/ocaml-github.git"
@@ -16,7 +16,7 @@ depends: [
   "ocamlfind"
   "ssl"
   "uri" {>= "1.5.0"}
-  "cohttp" {>= "0.12.0"}
+  "cohttp" {>= "0.14.0"}
   "lwt" {>= "2.4.3"}
   "atdgen" {>= "1.2.3"}
   "yojson" {>= "1.1.6"}


### PR DESCRIPTION
The opam file in the repository is out of date with respect to the opam-repository, which breaks pinning (or makes it less useful) and (maybe) makes Travis CI fail.