### PR TITLE
Use the appropriate option syntax for nullable fields

### DIFF
--- a/lib/github.atd
+++ b/lib/github.atd
@@ -167,7 +167,7 @@ type issue = {
   ~comments: int;
   ~created_at: string;
   ~updated_at: string;
-  ~closed_at: string option;
+  ?closed_at: string option;
   ?milestone: milestone option;
   ~sort <ocaml default="`Created">: issue_sort;
   ~direction <ocaml default="`Desc">: direction;


### PR DESCRIPTION
This is to fix a bug I surreptitiously introduced in aa8ba3f. Compare with the equivalent field in pulls, for instance.