### PR TITLE
Support retrieving of issues regardless of their state

### DIFF
--- a/lib/github_core.ml
+++ b/lib/github_core.ml
@@ -528,12 +528,13 @@ module Make(CL : Cohttp_lwt.Client) = struct
   end
 
   module Filter = struct
-    type state = [ `Open | `Closed ]
+    type state = [ `All | `Open | `Closed ]
     let string_of_state (s:state) =
       match s with
+      |`All -> "all"
       |`Open -> "open"
       |`Closed -> "closed"
-    
+
     type milestone_sort = [ `Due_date | `Completeness ]
     let string_of_sort (s:milestone_sort) =
       match s with

--- a/lib/github_s.mli
+++ b/lib/github_s.mli
@@ -137,7 +137,7 @@ module type Github = sig
   end
 
   module Filter : sig
-    type state = [ `Open | `Closed ]
+    type state = [ `All | `Open | `Closed ]
     type milestone_sort = [ `Due_date | `Completeness ]
     type issue_sort = [ `Created | `Updated | `Comments ]
     type direction = [ `Asc | `Desc ]


### PR DESCRIPTION
This is to retrieve open and closed issues in one request, as supported by the GitHub API, see #59.